### PR TITLE
Refactor service namespaces and improve organization

### DIFF
--- a/FactoryX.Application/DTOs/Requests/ShiftRequests/DeleteShiftRequest.cs
+++ b/FactoryX.Application/DTOs/Requests/ShiftRequests/DeleteShiftRequest.cs
@@ -1,0 +1,4 @@
+﻿namespace FactoryX.Application.DTOs.Requests.ShiftRequests;
+
+public sealed record DeleteShiftRequest(int Id, string Name);
+

--- a/FactoryX.Application/DTOs/Requests/ShiftRequests/InsertShiftRequest.cs
+++ b/FactoryX.Application/DTOs/Requests/ShiftRequests/InsertShiftRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace FactoryX.Application.DTOs.Requests.ShiftRequests;
+
+public sealed record InsertShiftRequest(int Id, string Name, TimeSpan StartTime, TimeSpan EndTime);

--- a/FactoryX.Application/DTOs/Requests/ShiftRequests/UpdateShiftRequest.cs
+++ b/FactoryX.Application/DTOs/Requests/ShiftRequests/UpdateShiftRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace FactoryX.Application.DTOs.Requests.ShiftRequests;
+
+public sealed record UpdateShiftRequest(int Id, string Name, TimeSpan StartTime, TimeSpan EndTime);

--- a/FactoryX.Application/DTOs/Requests/UserManagementRequests/ChangePasswordRequest.cs
+++ b/FactoryX.Application/DTOs/Requests/UserManagementRequests/ChangePasswordRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace FactoryX.Application.DTOs.Requests.UserManagementRequests;
+
+public sealed record ChangePasswordRequest(string CurrentPassword, string NewPassword, string ConfirmPassword);

--- a/FactoryX.Application/FactoryX.Application.csproj
+++ b/FactoryX.Application/FactoryX.Application.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\FactoryX.Domain\FactoryX.Domain.csproj" />
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="12.0.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
+    <ProjectReference Include="..\FactoryX.Infrastructure\FactoryX.Infrastructure.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/FactoryX.Application/Services/Abstracts/IMachineService.cs
+++ b/FactoryX.Application/Services/Abstracts/IMachineService.cs
@@ -1,6 +1,6 @@
 using FactoryX.Application.DTOs;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Abstracts;
 
 public interface IMachineService
 {

--- a/FactoryX.Application/Services/Abstracts/IOperatorService.cs
+++ b/FactoryX.Application/Services/Abstracts/IOperatorService.cs
@@ -1,6 +1,6 @@
 using FactoryX.Application.DTOs;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Abstracts;
 
 public interface IOperatorService
 {

--- a/FactoryX.Application/Services/Abstracts/IProductService.cs
+++ b/FactoryX.Application/Services/Abstracts/IProductService.cs
@@ -1,6 +1,6 @@
 using FactoryX.Application.DTOs;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Abstracts;
 
 public interface IProductService
 {

--- a/FactoryX.Application/Services/Abstracts/IProductionRecordService.cs
+++ b/FactoryX.Application/Services/Abstracts/IProductionRecordService.cs
@@ -1,6 +1,6 @@
 using FactoryX.Application.DTOs;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Abstracts;
 
 public interface IProductionRecordService
 {

--- a/FactoryX.Application/Services/Abstracts/IServiceManager.cs
+++ b/FactoryX.Application/Services/Abstracts/IServiceManager.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FactoryX.Application.Services.Abstracts;
+
+public interface IServiceManager
+{
+	IMachineService MachineService { get; }
+	IOperatorService OperatorService { get; }
+	IProductionRecordService ProductionRecordService { get; }
+	IProductService ProductService { get; }
+	IUserService UserService { get; }
+	IShiftService ShiftService { get; }
+	IWorkOrderService WorkOrderService { get; }
+}

--- a/FactoryX.Application/Services/Abstracts/IShiftService.cs
+++ b/FactoryX.Application/Services/Abstracts/IShiftService.cs
@@ -2,7 +2,7 @@ using FactoryX.Application.DTOs;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Abstracts;
 
 public interface IShiftService
 {

--- a/FactoryX.Application/Services/Abstracts/IUserService.cs
+++ b/FactoryX.Application/Services/Abstracts/IUserService.cs
@@ -1,6 +1,6 @@
 using FactoryX.Application.DTOs;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Abstracts;
 
 public interface IUserService
 {

--- a/FactoryX.Application/Services/Abstracts/IUserService.cs
+++ b/FactoryX.Application/Services/Abstracts/IUserService.cs
@@ -1,4 +1,5 @@
 using FactoryX.Application.DTOs;
+using FactoryX.Application.DTOs.Requests.UserManagementRequests;
 
 namespace FactoryX.Application.Services.Abstracts;
 
@@ -10,5 +11,5 @@ public interface IUserService
     Task<UserDto?> GetByUsernameAsync(string username);
     Task<UserProfileDto?> GetProfileAsync(int userId);
     Task UpdateProfileAsync(UserProfileDto dto);
-    Task<bool> ChangePasswordAsync(ChangePasswordDto dto);
+    Task<bool> ChangePasswordAsync(int userId, ChangePasswordRequest request);
 }

--- a/FactoryX.Application/Services/Abstracts/IWorkOrderService.cs
+++ b/FactoryX.Application/Services/Abstracts/IWorkOrderService.cs
@@ -1,6 +1,6 @@
 using FactoryX.Application.DTOs;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Abstracts;
 
 public interface IWorkOrderService
 {

--- a/FactoryX.Application/Services/Concretes/MachineService.cs
+++ b/FactoryX.Application/Services/Concretes/MachineService.cs
@@ -1,8 +1,9 @@
 using FactoryX.Application.DTOs;
+using FactoryX.Application.Services.Abstracts;
 using FactoryX.Domain.Entities;
 using FactoryX.Domain.Interfaces;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Concretes;
 
 public class MachineService : IMachineService
 {

--- a/FactoryX.Application/Services/Concretes/OperatorService.cs
+++ b/FactoryX.Application/Services/Concretes/OperatorService.cs
@@ -1,8 +1,9 @@
 using FactoryX.Application.DTOs;
+using FactoryX.Application.Services.Abstracts;
 using FactoryX.Domain.Entities;
 using FactoryX.Domain.Interfaces;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Concretes;
 
 public class OperatorService : IOperatorService
 {

--- a/FactoryX.Application/Services/Concretes/ProductService.cs
+++ b/FactoryX.Application/Services/Concretes/ProductService.cs
@@ -1,8 +1,9 @@
 using FactoryX.Application.DTOs;
+using FactoryX.Application.Services.Abstracts;
 using FactoryX.Domain.Entities;
 using FactoryX.Domain.Interfaces;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Concretes;
 
 public class ProductService : IProductService
 {

--- a/FactoryX.Application/Services/Concretes/ProductionRecordService.cs
+++ b/FactoryX.Application/Services/Concretes/ProductionRecordService.cs
@@ -1,8 +1,9 @@
 using FactoryX.Application.DTOs;
+using FactoryX.Application.Services.Abstracts;
 using FactoryX.Domain.Entities;
 using FactoryX.Domain.Interfaces;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Concretes;
 
 public class ProductionRecordService : IProductionRecordService
 {

--- a/FactoryX.Application/Services/Concretes/ServiceManager.cs
+++ b/FactoryX.Application/Services/Concretes/ServiceManager.cs
@@ -1,0 +1,39 @@
+﻿using FactoryX.Application.Services.Abstracts;
+
+namespace FactoryX.Application.Services.Concretes;
+
+public sealed class ServiceManager : IServiceManager
+{
+	private readonly IMachineService _machineService;
+	private readonly IOperatorService _operatorService;
+	private readonly IProductionRecordService _productionRecordService;
+	private readonly IProductService _productService;
+	private readonly IUserService _userService;
+	private readonly IShiftService _shiftService;
+	private readonly IWorkOrderService _workOrderService;
+
+	public ServiceManager(IMachineService machineService, IOperatorService operatorService, IProductionRecordService productionRecordService, IProductService productService, IUserService userService, IShiftService shiftService, IWorkOrderService workOrderService)
+	{
+		_machineService = machineService;
+		_operatorService = operatorService;
+		_productionRecordService = productionRecordService;
+		_productService = productService;
+		_userService = userService;
+		_shiftService = shiftService;
+		_workOrderService = workOrderService;
+	}
+
+	public IMachineService MachineService => _machineService;
+
+	public IOperatorService OperatorService => _operatorService;
+
+	public IProductionRecordService ProductionRecordService => _productionRecordService;
+
+	public IProductService ProductService => _productService;
+
+	public IUserService UserService => _userService;
+
+	public IShiftService ShiftService => _shiftService;
+
+	public IWorkOrderService WorkOrderService => _workOrderService;
+}

--- a/FactoryX.Application/Services/Concretes/ShiftService.cs
+++ b/FactoryX.Application/Services/Concretes/ShiftService.cs
@@ -1,10 +1,11 @@
 using FactoryX.Application.DTOs;
+using FactoryX.Application.Services.Abstracts;
 using FactoryX.Domain.Entities;
 using FactoryX.Domain.Interfaces;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Concretes;
 
 public class ShiftService : IShiftService
 {

--- a/FactoryX.Application/Services/Concretes/UserService.cs
+++ b/FactoryX.Application/Services/Concretes/UserService.cs
@@ -1,98 +1,101 @@
 using FactoryX.Application.DTOs;
-using FactoryX.Domain.Entities;
-using FactoryX.Domain.Interfaces;
+using FactoryX.Application.DTOs.Requests.UserManagementRequests;
 using FactoryX.Application.Helpers;
 using FactoryX.Application.Services.Abstracts;
+using FactoryX.Domain.Entities;
+using FactoryX.Infrastructure.Contracts;
 
 namespace FactoryX.Application.Services.Concretes;
 
 public class UserService : IUserService
 {
-    private readonly IRepository<User> _repository;
-    private readonly IUnitOfWork _unitOfWork;
+	private readonly IRepositoryManager _repositoryManager;
 
-    public UserService(IRepository<User> repository, IUnitOfWork unitOfWork)
-    {
-        _repository = repository;
-        _unitOfWork = unitOfWork;
-    }
+	public UserService(IRepositoryManager repositoryManager)
+	{
+		_repositoryManager = repositoryManager;
+	}
 
-    public async Task<UserDto?> AuthenticateAsync(UserLoginDto loginDto)
-    {
-        var users = await _repository.GetAllAsync();
-        var user = users.FirstOrDefault(u => u.Username == loginDto.Username);
-        if (user == null) return null;
-        if (!PasswordHasher.VerifyPassword(loginDto.Password, user.PasswordHash)) return null;
-        return ToDto(user);
-    }
+	public async Task<UserDto?> AuthenticateAsync(UserLoginDto loginDto)
+	{
+		var users = await _repositoryManager.UserRepository.GetAllAsync();
+		var user = users.FirstOrDefault(u => u.Username == loginDto.Username);
+		if (user == null) return null;
+		if (!PasswordHasher.VerifyPassword(loginDto.Password, user.PasswordHash)) return null;
+		return ToDto(user);
+	}
 
-    public async Task<UserDto> RegisterAsync(UserRegisterDto registerDto)
-    {
-        var users = await _repository.GetAllAsync();
-        if (users.Any(u => u.Username == registerDto.Username))
-            throw new InvalidOperationException("Username already exists.");
-        var user = new User
-        {
-            Username = registerDto.Username,
-            PasswordHash = PasswordHasher.HashPassword(registerDto.Password),
-            Role = registerDto.Role,
-            FullName = registerDto.FullName
-        };
-        await _repository.AddAsync(user);
-        await _unitOfWork.SaveChangesAsync();
-        return ToDto(user);
-    }
+	public async Task<UserDto> RegisterAsync(UserRegisterDto registerDto)
+	{
+		var users = await _repositoryManager.UserRepository.GetAllAsync();
+		if (users.Any(u => u.Username == registerDto.Username))
+			throw new InvalidOperationException("Username already exists.");
+		var user = new User
+		{
+			Username = registerDto.Username,
+			PasswordHash = PasswordHasher.HashPassword(registerDto.Password),
+			Role = registerDto.Role,
+			FullName = registerDto.FullName
+		};
+		_repositoryManager.UserRepository.Create(user);
+		await _repositoryManager.SaveAsync();
+		return ToDto(user);
+	}
 
-    public async Task<UserDto?> GetByIdAsync(int id)
-    {
-        var user = await _repository.GetByIdAsync(id);
-        return user == null ? null : ToDto(user);
-    }
+	public async Task<UserDto?> GetByIdAsync(int id)
+	{
+		var user = await _repositoryManager.UserRepository.GetByIdAsync(id);
+		return user == null ? null : ToDto(user);
+	}
 
-    public async Task<UserDto?> GetByUsernameAsync(string username)
-    {
-        var users = await _repository.GetAllAsync();
-        var user = users.FirstOrDefault(u => u.Username == username);
-        return user == null ? null : ToDto(user);
-    }
+	public async Task<UserDto?> GetByUsernameAsync(string username)
+	{
+		var users = await _repositoryManager.UserRepository.GetAllAsync();
+		var user = users.FirstOrDefault(u => u.Username == username);
+		return user == null ? null : ToDto(user);
+	}
 
-    public async Task<UserProfileDto?> GetProfileAsync(int userId)
-    {
-        var user = await _repository.GetByIdAsync(userId);
-        if (user == null) return null;
-        return new UserProfileDto
-        {
-            Id = user.Id,
-            UserName = user.Username,
-            FullName = user.FullName
-        };
-    }
+	public async Task<UserProfileDto?> GetProfileAsync(int userId)
+	{
+		var user = await _repositoryManager.UserRepository.GetByIdAsync(userId);
+		if (user == null) return null;
+		return new UserProfileDto
+		{
+			Id = user.Id,
+			UserName = user.Username,
+			FullName = user.FullName
+		};
+	}
 
-    public async Task UpdateProfileAsync(UserProfileDto dto)
-    {
-        var user = await _repository.GetByIdAsync(dto.Id);
-        if (user == null) throw new InvalidOperationException("Kullanıcı bulunamadı.");
-        user.Username = dto.UserName;
-        user.FullName = dto.FullName;
-        _repository.Update(user);
-        await _unitOfWork.SaveChangesAsync();
-    }
+	public async Task UpdateProfileAsync(UserProfileDto dto)
+	{
+		var user = await _repositoryManager.UserRepository.GetByIdAsync(id: dto.Id, trackChanges: true);
+		if (user == null) throw new InvalidOperationException("Kullanıcı bulunamadı.");
+		user.Username = dto.UserName;
+		user.FullName = dto.FullName;
+		_repositoryManager.UserRepository.Update(user);
+		await _repositoryManager.SaveAsync();
+	}
 
-    public async Task<bool> ChangePasswordAsync(ChangePasswordDto dto)
-    {
-        var user = await _repository.GetByIdAsync(dto.UserId);
-        if (user == null) return false;
-        if (!PasswordHasher.VerifyPassword(dto.CurrentPassword, user.PasswordHash)) return false;
-        user.PasswordHash = PasswordHasher.HashPassword(dto.NewPassword);
-        _repository.Update(user);
-        await _unitOfWork.SaveChangesAsync();
-        return true;
-    }
+	public async Task<bool> ChangePasswordAsync(int userId, ChangePasswordRequest request)
+	{
+		var user = await _repositoryManager.UserRepository.GetByIdAsync(id: userId, trackChanges: true);
+		if (user == null) return false;
+		if (!PasswordHasher.VerifyPassword(request.CurrentPassword, user.PasswordHash)) return false;
 
-    private static UserDto ToDto(User user) => new()
-    {
-        Id = user.Id,
-        Username = user.Username,
-        Role = user.Role
-    };
+		user.PasswordHash = PasswordHasher.HashPassword(request.NewPassword);
+		user.UpdatedAt = DateTime.UtcNow;
+
+		_repositoryManager.UserRepository.Update(user);
+		await _repositoryManager.SaveAsync();
+
+		return true;
+	}
+
+	private static UserDto ToDto(User user) => new()
+	{
+		Id = user.Id,
+		Username = user.Username,
+		Role = user.Role
+	};
 }

--- a/FactoryX.Application/Services/Concretes/UserService.cs
+++ b/FactoryX.Application/Services/Concretes/UserService.cs
@@ -2,8 +2,9 @@ using FactoryX.Application.DTOs;
 using FactoryX.Domain.Entities;
 using FactoryX.Domain.Interfaces;
 using FactoryX.Application.Helpers;
+using FactoryX.Application.Services.Abstracts;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Concretes;
 
 public class UserService : IUserService
 {

--- a/FactoryX.Application/Services/Concretes/WorkOrderService.cs
+++ b/FactoryX.Application/Services/Concretes/WorkOrderService.cs
@@ -1,8 +1,9 @@
 using FactoryX.Application.DTOs;
+using FactoryX.Application.Services.Abstracts;
 using FactoryX.Domain.Entities;
 using FactoryX.Domain.Interfaces;
 
-namespace FactoryX.Application.Services;
+namespace FactoryX.Application.Services.Concretes;
 
 public class WorkOrderService : IWorkOrderService
 {

--- a/FactoryX.Infrastructure/Contracts/IBaseRepository.cs
+++ b/FactoryX.Infrastructure/Contracts/IBaseRepository.cs
@@ -1,12 +1,14 @@
+using FactoryX.Domain.Common;
 using System.Linq.Expressions;
 
 namespace FactoryX.Infrastructure.Contracts;
 
-public interface IBaseRepository<TEntity> where TEntity : class
+public interface IBaseRepository<TEntity> where TEntity : EntityBase
 {
     Task<IEnumerable<TEntity>> GetAllAsync();
     Task<IEnumerable<TEntity>> GetAllAsync(Expression<Func<TEntity, bool>> predicate, bool trackChanges = false);
     IQueryable<TEntity> GetAllQueryableAsync(bool trackChanges = false);
+    Task<TEntity?> GetByIdAsync(int id, bool trackChanges = false);
     void Create(TEntity entity);
     void Update(TEntity entity);
     void Remove(TEntity entity);

--- a/FactoryX.Infrastructure/Contracts/IBaseRepository.cs
+++ b/FactoryX.Infrastructure/Contracts/IBaseRepository.cs
@@ -2,12 +2,12 @@ using System.Linq.Expressions;
 
 namespace FactoryX.Infrastructure.Contracts;
 
-public interface IBaseRepository<T> where T : class
+public interface IBaseRepository<TEntity> where TEntity : class
 {
-    Task<IEnumerable<T>> GetAllAsync();
-    Task<IEnumerable<T>> GetAllAsync(Expression<Func<T, bool>> predicate, bool trackChanges = false);
-    IQueryable<T> GetAllQueryableAsync(bool trackChanges = false);
-    void Create(T entity);
-    void Update(T entity);
-    void Remove(T entity);
+    Task<IEnumerable<TEntity>> GetAllAsync();
+    Task<IEnumerable<TEntity>> GetAllAsync(Expression<Func<TEntity, bool>> predicate, bool trackChanges = false);
+    IQueryable<TEntity> GetAllQueryableAsync(bool trackChanges = false);
+    void Create(TEntity entity);
+    void Update(TEntity entity);
+    void Remove(TEntity entity);
 }

--- a/FactoryX.Infrastructure/Contracts/IDowntimeRepository.cs
+++ b/FactoryX.Infrastructure/Contracts/IDowntimeRepository.cs
@@ -1,0 +1,7 @@
+﻿using FactoryX.Domain.Entities;
+
+namespace FactoryX.Infrastructure.Contracts;
+
+public interface IDowntimeRepository : IBaseRepository<Downtime>
+{
+}

--- a/FactoryX.Infrastructure/Contracts/IMaterialRepository.cs
+++ b/FactoryX.Infrastructure/Contracts/IMaterialRepository.cs
@@ -1,0 +1,8 @@
+using FactoryX.Domain.Entities;
+
+namespace FactoryX.Infrastructure.Contracts;
+
+public interface IMaterialRepository : IBaseRepository<Material>
+{
+
+}

--- a/FactoryX.Infrastructure/Contracts/IMaterialUsageRepository.cs
+++ b/FactoryX.Infrastructure/Contracts/IMaterialUsageRepository.cs
@@ -1,0 +1,8 @@
+using FactoryX.Domain.Entities;
+
+namespace FactoryX.Infrastructure.Contracts;
+
+public interface IMaterialUsageRepository : IBaseRepository<MaterialUsage>
+{
+
+}

--- a/FactoryX.Infrastructure/Contracts/IProductRepository.cs
+++ b/FactoryX.Infrastructure/Contracts/IProductRepository.cs
@@ -1,0 +1,8 @@
+using FactoryX.Domain.Entities;
+
+namespace FactoryX.Infrastructure.Contracts;
+
+public interface IProductRepository : IBaseRepository<Product>
+{
+
+}

--- a/FactoryX.Infrastructure/Contracts/IProductionRecordRepository.cs
+++ b/FactoryX.Infrastructure/Contracts/IProductionRecordRepository.cs
@@ -1,0 +1,8 @@
+using FactoryX.Domain.Entities;
+
+namespace FactoryX.Infrastructure.Contracts;
+
+public interface IProductionRecordRepository : IBaseRepository<ProductionRecord>
+{
+
+}

--- a/FactoryX.Infrastructure/Contracts/IRepositoryManager.cs
+++ b/FactoryX.Infrastructure/Contracts/IRepositoryManager.cs
@@ -8,5 +8,9 @@ public interface IRepositoryManager
     IShiftRepository ShiftRepository { get; }
     IDowntimeRepository DowntimeRepository { get; }
     IUserRepository UserRepository { get; }
+    IProductRepository ProductRepository { get; }
+    IMaterialRepository MaterialRepository { get; }
+    IMaterialUsageRepository MaterialUsageRepository { get; }
+    IProductionRecordRepository ProductionRecordRepository { get; }
     Task SaveAsync();
 }

--- a/FactoryX.Infrastructure/Contracts/IRepositoryManager.cs
+++ b/FactoryX.Infrastructure/Contracts/IRepositoryManager.cs
@@ -6,4 +6,7 @@ public interface IRepositoryManager
     IOperatorRepository OperatorRepository { get; }
     IWorkOrderRepository WorkOrderRepository { get; }
     IShiftRepository ShiftRepository { get; }
+    IDowntimeRepository DowntimeRepository { get; }
+    IUserRepository UserRepository { get; }
+    Task SaveAsync();
 }

--- a/FactoryX.Infrastructure/Contracts/IUserRepository.cs
+++ b/FactoryX.Infrastructure/Contracts/IUserRepository.cs
@@ -1,0 +1,7 @@
+﻿using FactoryX.Domain.Entities;
+
+namespace FactoryX.Infrastructure.Contracts;
+
+public interface IUserRepository : IBaseRepository<User>
+{
+}

--- a/FactoryX.Infrastructure/DependencyInjection.cs
+++ b/FactoryX.Infrastructure/DependencyInjection.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using FactoryX.Domain.Interfaces;
-using FactoryX.Application.Services;
 using FactoryX.Infrastructure.Contracts;
 using FactoryX.Infrastructure.Repositories;
 
@@ -21,6 +20,8 @@ public static class DependencyInjection
         services.AddScoped<IOperatorRepository, OperatorRepository>();
 		services.AddScoped<IShiftRepository, ShiftRepository>();
 		services.AddScoped<IWorkOrderRepository, WorkOrderRepository>();
+        services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IDowntimeRepository, DowntimeRepository>();
 		services.AddScoped<IRepositoryManager, RepositoryManager>();
         //services.AddScoped(typeof(IBaseRepository<>), typeof(BaseRepository<>));
         

--- a/FactoryX.Infrastructure/EntityConfigurations/DowntimeConfiguration.cs
+++ b/FactoryX.Infrastructure/EntityConfigurations/DowntimeConfiguration.cs
@@ -8,6 +8,8 @@ public class DowntimeConfiguration : EntityBaseConfiguration<Downtime>
 {
     public override void Configure(EntityTypeBuilder<Downtime> builder)
     {
+        base.Configure(builder);
+
         builder.ToTable("downtimes");
 
         builder.Property(d => d.Reason)

--- a/FactoryX.Infrastructure/EntityConfigurations/MachineConfiguration.cs
+++ b/FactoryX.Infrastructure/EntityConfigurations/MachineConfiguration.cs
@@ -8,6 +8,8 @@ public class MachineConfiguration : EntityBaseConfiguration<Machine>
 {
     public override void Configure(EntityTypeBuilder<Machine> builder)
     {
+        base.Configure(builder);
+
         builder.ToTable("machines");
 
         builder.Property(m => m.Name)

--- a/FactoryX.Infrastructure/EntityConfigurations/MaterialConfiguration.cs
+++ b/FactoryX.Infrastructure/EntityConfigurations/MaterialConfiguration.cs
@@ -8,6 +8,8 @@ public class MaterialConfiguration : EntityBaseConfiguration<Material>
 {
     public override void Configure(EntityTypeBuilder<Material> builder)
     {
+        base.Configure(builder);
+
         builder.ToTable("materials");
 
         builder.Property(m => m.Code)

--- a/FactoryX.Infrastructure/EntityConfigurations/MaterialUsageConfiguration.cs
+++ b/FactoryX.Infrastructure/EntityConfigurations/MaterialUsageConfiguration.cs
@@ -8,6 +8,8 @@ public class MaterialUsageConfiguration : EntityBaseConfiguration<MaterialUsage>
 {
     public override void Configure(EntityTypeBuilder<MaterialUsage> builder)
     {
+        base.Configure(builder);
+
         builder.ToTable("material_usages");
 
         builder.Property(mu => mu.Quantity)

--- a/FactoryX.Infrastructure/EntityConfigurations/OperatorConfiguration.cs
+++ b/FactoryX.Infrastructure/EntityConfigurations/OperatorConfiguration.cs
@@ -8,6 +8,8 @@ public class OperatorConfiguration : EntityBaseConfiguration<Operator>
 {
     public override void Configure(EntityTypeBuilder<Operator> builder)
     {
+        base.Configure(builder);
+
         builder.ToTable("operators");
 
         builder.Property(o => o.Name)

--- a/FactoryX.Infrastructure/EntityConfigurations/ProductConfiguration.cs
+++ b/FactoryX.Infrastructure/EntityConfigurations/ProductConfiguration.cs
@@ -8,6 +8,8 @@ public class ProductConfiguration : EntityBaseConfiguration<Product>
 {
     public override void Configure(EntityTypeBuilder<Product> builder)
     {
+        base.Configure(builder);
+
         builder.ToTable("products");
 
         builder.HasIndex(p => p.Code)

--- a/FactoryX.Infrastructure/EntityConfigurations/ProductionRecordConfiguration.cs
+++ b/FactoryX.Infrastructure/EntityConfigurations/ProductionRecordConfiguration.cs
@@ -8,6 +8,8 @@ public class ProductionRecordConfiguration : EntityBaseConfiguration<ProductionR
 {
     public override void Configure(EntityTypeBuilder<ProductionRecord> builder)
     {
+        base.Configure(builder);
+
         builder.ToTable("production_records");
 
         builder.Property(pr => pr.QuantityProduced)

--- a/FactoryX.Infrastructure/EntityConfigurations/ShiftConfiguration.cs
+++ b/FactoryX.Infrastructure/EntityConfigurations/ShiftConfiguration.cs
@@ -8,6 +8,8 @@ public class ShiftConfiguration : EntityBaseConfiguration<Shift>
 {
     public override void Configure(EntityTypeBuilder<Shift> builder)
     {
+        base.Configure(builder);
+
         builder.ToTable("shifts");
 
         builder.Property(s => s.Name)

--- a/FactoryX.Infrastructure/EntityConfigurations/UserConfiguration.cs
+++ b/FactoryX.Infrastructure/EntityConfigurations/UserConfiguration.cs
@@ -8,6 +8,8 @@ public class UserConfiguration : EntityBaseConfiguration<User>
 {
     public override void Configure(EntityTypeBuilder<User> builder)
     {
+        base.Configure(builder);
+
         builder.ToTable("users");
 
         builder.HasIndex(u => u.Username).IsUnique();

--- a/FactoryX.Infrastructure/EntityConfigurations/WorkOrderConfiguration.cs
+++ b/FactoryX.Infrastructure/EntityConfigurations/WorkOrderConfiguration.cs
@@ -8,6 +8,8 @@ public class WorkOrderConfiguration : EntityBaseConfiguration<WorkOrder>
 {
     public override void Configure(EntityTypeBuilder<WorkOrder> builder)
     {
+        base.Configure(builder);
+
         builder.ToTable("work_orders");
 
         builder.Property(w => w.Status).IsRequired().HasMaxLength(30);

--- a/FactoryX.Infrastructure/FactoryX.Infrastructure.csproj
+++ b/FactoryX.Infrastructure/FactoryX.Infrastructure.csproj
@@ -2,7 +2,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FactoryX.Domain\FactoryX.Domain.csproj" />
-    <ProjectReference Include="..\FactoryX.Application\FactoryX.Application.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FactoryX.Infrastructure/Migrations/20250728084255_UpdateEntitiesWithRelations.Designer.cs
+++ b/FactoryX.Infrastructure/Migrations/20250728084255_UpdateEntitiesWithRelations.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FactoryX.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FactoryX.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250728084255_UpdateEntitiesWithRelations")]
+    partial class UpdateEntitiesWithRelations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FactoryX.Infrastructure/Migrations/20250728084255_UpdateEntitiesWithRelations.cs
+++ b/FactoryX.Infrastructure/Migrations/20250728084255_UpdateEntitiesWithRelations.cs
@@ -1,0 +1,1046 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FactoryX.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateEntitiesWithRelations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Users",
+                table: "Users");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Shifts",
+                table: "Shifts");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Products",
+                table: "Products");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Operators",
+                table: "Operators");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Materials",
+                table: "Materials");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Machines",
+                table: "Machines");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Downtimes",
+                table: "Downtimes");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_WorkOrders",
+                table: "WorkOrders");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ProductionRecords",
+                table: "ProductionRecords");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_MaterialUsages",
+                table: "MaterialUsages");
+
+            migrationBuilder.RenameTable(
+                name: "Users",
+                newName: "users");
+
+            migrationBuilder.RenameTable(
+                name: "Shifts",
+                newName: "shifts");
+
+            migrationBuilder.RenameTable(
+                name: "Products",
+                newName: "products");
+
+            migrationBuilder.RenameTable(
+                name: "Operators",
+                newName: "operators");
+
+            migrationBuilder.RenameTable(
+                name: "Materials",
+                newName: "materials");
+
+            migrationBuilder.RenameTable(
+                name: "Machines",
+                newName: "machines");
+
+            migrationBuilder.RenameTable(
+                name: "Downtimes",
+                newName: "downtimes");
+
+            migrationBuilder.RenameTable(
+                name: "WorkOrders",
+                newName: "work_orders");
+
+            migrationBuilder.RenameTable(
+                name: "ProductionRecords",
+                newName: "production_records");
+
+            migrationBuilder.RenameTable(
+                name: "MaterialUsages",
+                newName: "material_usages");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "users",
+                newName: "id");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "shifts",
+                newName: "id");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "products",
+                newName: "id");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "operators",
+                newName: "id");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "materials",
+                newName: "id");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "machines",
+                newName: "id");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "downtimes",
+                newName: "id");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "work_orders",
+                newName: "id");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "production_records",
+                newName: "id");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "material_usages",
+                newName: "id");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Username",
+                table: "users",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Role",
+                table: "users",
+                type: "character varying(30)",
+                maxLength: 30,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_at",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "shifts",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "shifts",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_at",
+                table: "shifts",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "products",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "products",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Code",
+                table: "products",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "products",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_at",
+                table: "products",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "operators",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "EmployeeNumber",
+                table: "operators",
+                type: "character varying(30)",
+                maxLength: 30,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "operators",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_at",
+                table: "operators",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Unit",
+                table: "materials",
+                type: "character varying(30)",
+                maxLength: 30,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "materials",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Code",
+                table: "materials",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "materials",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_at",
+                table: "materials",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "machines",
+                type: "character varying(30)",
+                maxLength: 30,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "machines",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "machines",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_at",
+                table: "machines",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Reason",
+                table: "downtimes",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "downtimes",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_at",
+                table: "downtimes",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "work_orders",
+                type: "character varying(30)",
+                maxLength: 30,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "work_orders",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_at",
+                table: "work_orders",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "production_records",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_at",
+                table: "production_records",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "material_usages",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_at",
+                table: "material_usages",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_users",
+                table: "users",
+                column: "id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_shifts",
+                table: "shifts",
+                column: "id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_products",
+                table: "products",
+                column: "id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_operators",
+                table: "operators",
+                column: "id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_materials",
+                table: "materials",
+                column: "id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_machines",
+                table: "machines",
+                column: "id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_downtimes",
+                table: "downtimes",
+                column: "id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_work_orders",
+                table: "work_orders",
+                column: "id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_production_records",
+                table: "production_records",
+                column: "id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_material_usages",
+                table: "material_usages",
+                column: "id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_users_Username",
+                table: "users",
+                column: "Username",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_products_Code",
+                table: "products",
+                column: "Code",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_materials_Code",
+                table: "materials",
+                column: "Code",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_downtimes_MachineId",
+                table: "downtimes",
+                column: "MachineId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_work_orders_MachineId",
+                table: "work_orders",
+                column: "MachineId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_work_orders_ProductId",
+                table: "work_orders",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_production_records_OperatorId",
+                table: "production_records",
+                column: "OperatorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_production_records_WorkOrderId",
+                table: "production_records",
+                column: "WorkOrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_material_usages_MaterialId",
+                table: "material_usages",
+                column: "MaterialId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_material_usages_WorkOrderId",
+                table: "material_usages",
+                column: "WorkOrderId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_downtimes_machines_MachineId",
+                table: "downtimes",
+                column: "MachineId",
+                principalTable: "machines",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_material_usages_materials_MaterialId",
+                table: "material_usages",
+                column: "MaterialId",
+                principalTable: "materials",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_material_usages_work_orders_WorkOrderId",
+                table: "material_usages",
+                column: "WorkOrderId",
+                principalTable: "work_orders",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_production_records_operators_OperatorId",
+                table: "production_records",
+                column: "OperatorId",
+                principalTable: "operators",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_production_records_work_orders_WorkOrderId",
+                table: "production_records",
+                column: "WorkOrderId",
+                principalTable: "work_orders",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_work_orders_machines_MachineId",
+                table: "work_orders",
+                column: "MachineId",
+                principalTable: "machines",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_work_orders_products_ProductId",
+                table: "work_orders",
+                column: "ProductId",
+                principalTable: "products",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_downtimes_machines_MachineId",
+                table: "downtimes");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_material_usages_materials_MaterialId",
+                table: "material_usages");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_material_usages_work_orders_WorkOrderId",
+                table: "material_usages");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_production_records_operators_OperatorId",
+                table: "production_records");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_production_records_work_orders_WorkOrderId",
+                table: "production_records");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_work_orders_machines_MachineId",
+                table: "work_orders");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_work_orders_products_ProductId",
+                table: "work_orders");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_users",
+                table: "users");
+
+            migrationBuilder.DropIndex(
+                name: "IX_users_Username",
+                table: "users");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_shifts",
+                table: "shifts");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_products",
+                table: "products");
+
+            migrationBuilder.DropIndex(
+                name: "IX_products_Code",
+                table: "products");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_operators",
+                table: "operators");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_materials",
+                table: "materials");
+
+            migrationBuilder.DropIndex(
+                name: "IX_materials_Code",
+                table: "materials");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_machines",
+                table: "machines");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_downtimes",
+                table: "downtimes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_downtimes_MachineId",
+                table: "downtimes");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_work_orders",
+                table: "work_orders");
+
+            migrationBuilder.DropIndex(
+                name: "IX_work_orders_MachineId",
+                table: "work_orders");
+
+            migrationBuilder.DropIndex(
+                name: "IX_work_orders_ProductId",
+                table: "work_orders");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_production_records",
+                table: "production_records");
+
+            migrationBuilder.DropIndex(
+                name: "IX_production_records_OperatorId",
+                table: "production_records");
+
+            migrationBuilder.DropIndex(
+                name: "IX_production_records_WorkOrderId",
+                table: "production_records");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_material_usages",
+                table: "material_usages");
+
+            migrationBuilder.DropIndex(
+                name: "IX_material_usages_MaterialId",
+                table: "material_usages");
+
+            migrationBuilder.DropIndex(
+                name: "IX_material_usages_WorkOrderId",
+                table: "material_usages");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "updated_at",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "shifts");
+
+            migrationBuilder.DropColumn(
+                name: "updated_at",
+                table: "shifts");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "products");
+
+            migrationBuilder.DropColumn(
+                name: "updated_at",
+                table: "products");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "operators");
+
+            migrationBuilder.DropColumn(
+                name: "updated_at",
+                table: "operators");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "materials");
+
+            migrationBuilder.DropColumn(
+                name: "updated_at",
+                table: "materials");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "machines");
+
+            migrationBuilder.DropColumn(
+                name: "updated_at",
+                table: "machines");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "downtimes");
+
+            migrationBuilder.DropColumn(
+                name: "updated_at",
+                table: "downtimes");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "work_orders");
+
+            migrationBuilder.DropColumn(
+                name: "updated_at",
+                table: "work_orders");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "production_records");
+
+            migrationBuilder.DropColumn(
+                name: "updated_at",
+                table: "production_records");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "material_usages");
+
+            migrationBuilder.DropColumn(
+                name: "updated_at",
+                table: "material_usages");
+
+            migrationBuilder.RenameTable(
+                name: "users",
+                newName: "Users");
+
+            migrationBuilder.RenameTable(
+                name: "shifts",
+                newName: "Shifts");
+
+            migrationBuilder.RenameTable(
+                name: "products",
+                newName: "Products");
+
+            migrationBuilder.RenameTable(
+                name: "operators",
+                newName: "Operators");
+
+            migrationBuilder.RenameTable(
+                name: "materials",
+                newName: "Materials");
+
+            migrationBuilder.RenameTable(
+                name: "machines",
+                newName: "Machines");
+
+            migrationBuilder.RenameTable(
+                name: "downtimes",
+                newName: "Downtimes");
+
+            migrationBuilder.RenameTable(
+                name: "work_orders",
+                newName: "WorkOrders");
+
+            migrationBuilder.RenameTable(
+                name: "production_records",
+                newName: "ProductionRecords");
+
+            migrationBuilder.RenameTable(
+                name: "material_usages",
+                newName: "MaterialUsages");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                table: "Users",
+                newName: "Id");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                table: "Shifts",
+                newName: "Id");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                table: "Products",
+                newName: "Id");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                table: "Operators",
+                newName: "Id");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                table: "Materials",
+                newName: "Id");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                table: "Machines",
+                newName: "Id");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                table: "Downtimes",
+                newName: "Id");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                table: "WorkOrders",
+                newName: "Id");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                table: "ProductionRecords",
+                newName: "Id");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                table: "MaterialUsages",
+                newName: "Id");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Username",
+                table: "Users",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Role",
+                table: "Users",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(30)",
+                oldMaxLength: 30);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Shifts",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Products",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Products",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Code",
+                table: "Products",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Operators",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "EmployeeNumber",
+                table: "Operators",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(30)",
+                oldMaxLength: 30);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Unit",
+                table: "Materials",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(30)",
+                oldMaxLength: 30);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Materials",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Code",
+                table: "Materials",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Machines",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(30)",
+                oldMaxLength: 30);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Machines",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Reason",
+                table: "Downtimes",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "WorkOrders",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(30)",
+                oldMaxLength: 30);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Users",
+                table: "Users",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Shifts",
+                table: "Shifts",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Products",
+                table: "Products",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Operators",
+                table: "Operators",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Materials",
+                table: "Materials",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Machines",
+                table: "Machines",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Downtimes",
+                table: "Downtimes",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_WorkOrders",
+                table: "WorkOrders",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ProductionRecords",
+                table: "ProductionRecords",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_MaterialUsages",
+                table: "MaterialUsages",
+                column: "Id");
+        }
+    }
+}

--- a/FactoryX.Infrastructure/Repositories/BaseRepository.cs
+++ b/FactoryX.Infrastructure/Repositories/BaseRepository.cs
@@ -4,49 +4,49 @@ using Microsoft.EntityFrameworkCore;
 
 namespace FactoryX.Infrastructure.Repositories;
 
-public class BaseRepository<T> : IBaseRepository<T> where T : class
+public class BaseRepository<TEntity> : IBaseRepository<TEntity> where TEntity : class
 {
-    internal readonly AppDbContext _context;
-    //internal DbSet<T> _dbset; 
+    private readonly AppDbContext _context;
+    private DbSet<TEntity> _dbset; 
 
     public BaseRepository(AppDbContext context)
     {
         _context = context;
-        //_dbset = context.Set<T>();
-	}
-
-    public void Create(T entity)
-    {
-        _context.Set<T>().Add(entity);
+        _dbset = context.Set<TEntity>();
     }
 
-    public Task<IEnumerable<T>> GetAllAsync()
+    public void Create(TEntity entity)
     {
-        return Task.FromResult(_context.Set<T>().AsEnumerable());
+        _dbset.Add(entity);
     }
 
-    public Task<IEnumerable<T>> GetAllAsync(Expression<Func<T, bool>> predicate, bool trackChanges = false)
+    public Task<IEnumerable<TEntity>> GetAllAsync()
+    {
+        return Task.FromResult(_dbset.AsEnumerable());
+    }
+
+    public Task<IEnumerable<TEntity>> GetAllAsync(Expression<Func<TEntity, bool>> predicate, bool trackChanges = false)
     {
         if (trackChanges)
         {
-            return Task.FromResult(_context.Set<T>().Where(predicate).AsEnumerable());
+            return Task.FromResult(_dbset.Where(predicate).AsEnumerable());
         }
-        return Task.FromResult(_context.Set<T>().AsNoTracking().Where(predicate).AsEnumerable());
+        return Task.FromResult(_dbset.AsNoTracking().Where(predicate).AsEnumerable());
     }
 
-    public IQueryable<T> GetAllQueryableAsync(bool trackChanges = false)
+    public IQueryable<TEntity> GetAllQueryableAsync(bool trackChanges = false)
     {
         return trackChanges
-            ? _context.Set<T>()
-            : _context.Set<T>().AsNoTracking();
+            ? _dbset
+            : _dbset.AsNoTracking();
     }
-    public void Remove(T entity)
+    public void Remove(TEntity entity)
     {
-        _context.Set<T>().Remove(entity);
+        _dbset.Remove(entity);
     }
 
-    public void Update(T entity)
+    public void Update(TEntity entity)
     {
-        _context.Set<T>().Update(entity);
+        _dbset.Update(entity);
     }
 }

--- a/FactoryX.Infrastructure/Repositories/BaseRepository.cs
+++ b/FactoryX.Infrastructure/Repositories/BaseRepository.cs
@@ -1,10 +1,11 @@
 using System.Linq.Expressions;
+using FactoryX.Domain.Common;
 using FactoryX.Infrastructure.Contracts;
 using Microsoft.EntityFrameworkCore;
 
 namespace FactoryX.Infrastructure.Repositories;
 
-public class BaseRepository<TEntity> : IBaseRepository<TEntity> where TEntity : class
+public class BaseRepository<TEntity> : IBaseRepository<TEntity> where TEntity : EntityBase
 {
     private readonly AppDbContext _context;
     private DbSet<TEntity> _dbset; 
@@ -13,11 +14,6 @@ public class BaseRepository<TEntity> : IBaseRepository<TEntity> where TEntity : 
     {
         _context = context;
         _dbset = context.Set<TEntity>();
-    }
-
-    public void Create(TEntity entity)
-    {
-        _dbset.Add(entity);
     }
 
     public Task<IEnumerable<TEntity>> GetAllAsync()
@@ -40,7 +36,22 @@ public class BaseRepository<TEntity> : IBaseRepository<TEntity> where TEntity : 
             ? _dbset
             : _dbset.AsNoTracking();
     }
-    public void Remove(TEntity entity)
+
+    public async Task<TEntity?> GetByIdAsync(int id, bool trackChanges = false)
+    {
+		if (trackChanges)
+		{
+			return await _dbset.FirstOrDefaultAsync(e => e.Id == id);
+		}
+		return await _dbset.AsNoTracking().FirstOrDefaultAsync(e => e.Id == id);
+	}
+
+	public void Create(TEntity entity)
+	{
+		_dbset.Add(entity);
+	}
+
+	public void Remove(TEntity entity)
     {
         _dbset.Remove(entity);
     }

--- a/FactoryX.Infrastructure/Repositories/DowntimeRepository.cs
+++ b/FactoryX.Infrastructure/Repositories/DowntimeRepository.cs
@@ -1,0 +1,11 @@
+﻿using FactoryX.Domain.Entities;
+using FactoryX.Infrastructure.Contracts;
+
+namespace FactoryX.Infrastructure.Repositories;
+
+public class DowntimeRepository : BaseRepository<Downtime>, IDowntimeRepository
+{
+	public DowntimeRepository(AppDbContext context) : base(context)
+	{
+	}
+}

--- a/FactoryX.Infrastructure/Repositories/MaterialRepository.cs
+++ b/FactoryX.Infrastructure/Repositories/MaterialRepository.cs
@@ -1,0 +1,12 @@
+using FactoryX.Domain.Entities;
+using FactoryX.Infrastructure.Contracts;
+
+namespace FactoryX.Infrastructure.Repositories;
+
+public class MaterialRepository : BaseRepository<Material>, IMaterialRepository
+{
+    public MaterialRepository(AppDbContext context) : base(context)
+    {
+    }
+}
+

--- a/FactoryX.Infrastructure/Repositories/MaterialUsageRepository.cs
+++ b/FactoryX.Infrastructure/Repositories/MaterialUsageRepository.cs
@@ -1,0 +1,11 @@
+using FactoryX.Domain.Entities;
+using FactoryX.Infrastructure.Contracts;
+
+namespace FactoryX.Infrastructure.Repositories;
+
+public class MaterialUsageRepository : BaseRepository<MaterialUsage>, IMaterialUsageRepository
+{
+    public MaterialUsageRepository(AppDbContext context) : base(context)
+    {
+    }
+}

--- a/FactoryX.Infrastructure/Repositories/ProductRepository.cs
+++ b/FactoryX.Infrastructure/Repositories/ProductRepository.cs
@@ -1,0 +1,12 @@
+using FactoryX.Domain.Entities;
+using FactoryX.Infrastructure.Contracts;
+
+namespace FactoryX.Infrastructure.Repositories;
+
+public class ProductRepository : BaseRepository<Product>, IProductRepository
+{
+    public ProductRepository(AppDbContext context) : base(context)
+    {
+    }
+}
+

--- a/FactoryX.Infrastructure/Repositories/ProductionRecordRepository.cs
+++ b/FactoryX.Infrastructure/Repositories/ProductionRecordRepository.cs
@@ -1,0 +1,12 @@
+using FactoryX.Domain.Entities;
+using FactoryX.Infrastructure.Contracts;
+
+namespace FactoryX.Infrastructure.Repositories;
+
+public class ProductionRecordRepository : BaseRepository<ProductionRecord>, IProductionRecordRepository
+{
+    public ProductionRecordRepository(AppDbContext context) : base(context)
+    {
+    }
+}
+

--- a/FactoryX.Infrastructure/Repositories/RepositoryManager.cs
+++ b/FactoryX.Infrastructure/Repositories/RepositoryManager.cs
@@ -4,25 +4,41 @@ namespace FactoryX.Infrastructure.Repositories;
 
 public class RepositoryManager : IRepositoryManager
 {
-	public IMachineRepository _machineRepository;
-	public IOperatorRepository _operatorRepository;
-	public IWorkOrderRepository _workOrderRepository;
-	public IShiftRepository _shiftRepository;
+	private readonly AppDbContext _context;
+	private readonly IMachineRepository _machineRepository;
+	private readonly IOperatorRepository _operatorRepository;
+	private readonly IWorkOrderRepository _workOrderRepository;
+	private readonly IShiftRepository _shiftRepository;
+	private readonly IDowntimeRepository _downtimeRepository;
+	private readonly IUserRepository _userRepository;
 
 	public RepositoryManager(
+		AppDbContext context,
 		IMachineRepository machineRepository,
 		IOperatorRepository operatorRepository,
 		IWorkOrderRepository workOrderRepository,
-		IShiftRepository shiftRepository)
+		IShiftRepository shiftRepository,
+		IDowntimeRepository downtimeRepository,
+		IUserRepository userRepository)
 	{
+		_context = context;
 		_machineRepository = machineRepository;
 		_operatorRepository = operatorRepository;
 		_workOrderRepository = workOrderRepository;
 		_shiftRepository = shiftRepository;
+		_downtimeRepository = downtimeRepository;
+		_userRepository = userRepository;
 	}
 
 	public IMachineRepository MachineRepository => _machineRepository;
 	public IOperatorRepository OperatorRepository => _operatorRepository;
 	public IWorkOrderRepository WorkOrderRepository => _workOrderRepository;
 	public IShiftRepository ShiftRepository => _shiftRepository;
+	public IDowntimeRepository DowntimeRepository => _downtimeRepository;
+	public IUserRepository UserRepository => _userRepository;
+
+	public async Task SaveAsync()
+	{
+		await _context.SaveChangesAsync();
+	}
 }

--- a/FactoryX.Infrastructure/Repositories/RepositoryManager.cs
+++ b/FactoryX.Infrastructure/Repositories/RepositoryManager.cs
@@ -11,6 +11,10 @@ public class RepositoryManager : IRepositoryManager
 	private readonly IShiftRepository _shiftRepository;
 	private readonly IDowntimeRepository _downtimeRepository;
 	private readonly IUserRepository _userRepository;
+	private readonly IProductRepository _productRepository;
+	private readonly IMaterialRepository _materialRepository;
+	private readonly IMaterialUsageRepository _materialUsageRepository;
+	private readonly IProductionRecordRepository _productionRecordRepository;
 
 	public RepositoryManager(
 		AppDbContext context,
@@ -19,7 +23,11 @@ public class RepositoryManager : IRepositoryManager
 		IWorkOrderRepository workOrderRepository,
 		IShiftRepository shiftRepository,
 		IDowntimeRepository downtimeRepository,
-		IUserRepository userRepository)
+		IUserRepository userRepository,
+		IProductRepository productRepository,
+		IMaterialRepository materialRepository,
+		IMaterialUsageRepository materialUsageRepository,
+		IProductionRecordRepository productionRecordRepository)
 	{
 		_context = context;
 		_machineRepository = machineRepository;
@@ -28,6 +36,10 @@ public class RepositoryManager : IRepositoryManager
 		_shiftRepository = shiftRepository;
 		_downtimeRepository = downtimeRepository;
 		_userRepository = userRepository;
+		_productRepository = productRepository;
+		_materialRepository = materialRepository;
+		_materialUsageRepository = materialUsageRepository;
+		_productionRecordRepository = productionRecordRepository;
 	}
 
 	public IMachineRepository MachineRepository => _machineRepository;
@@ -36,6 +48,10 @@ public class RepositoryManager : IRepositoryManager
 	public IShiftRepository ShiftRepository => _shiftRepository;
 	public IDowntimeRepository DowntimeRepository => _downtimeRepository;
 	public IUserRepository UserRepository => _userRepository;
+	public IProductRepository ProductRepository => _productRepository;
+	public IMaterialRepository MaterialRepository => _materialRepository;
+	public IMaterialUsageRepository MaterialUsageRepository => _materialUsageRepository;
+	public IProductionRecordRepository ProductionRecordRepository => _productionRecordRepository;
 
 	public async Task SaveAsync()
 	{

--- a/FactoryX.Infrastructure/Repositories/UserRepository.cs
+++ b/FactoryX.Infrastructure/Repositories/UserRepository.cs
@@ -1,0 +1,11 @@
+﻿using FactoryX.Domain.Entities;
+using FactoryX.Infrastructure.Contracts;
+
+namespace FactoryX.Infrastructure.Repositories;
+
+public class UserRepository : BaseRepository<User>, IUserRepository
+{
+	public UserRepository(AppDbContext context) : base(context)
+	{
+	}
+}

--- a/FactoryX.Web/Controllers/AccountController.cs
+++ b/FactoryX.Web/Controllers/AccountController.cs
@@ -1,11 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
-using FactoryX.Application.Services;
 using FactoryX.Application.DTOs;
 using FactoryX.Web.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
+using FactoryX.Application.Services.Abstracts;
 
 namespace FactoryX.Web.Controllers;
 

--- a/FactoryX.Web/Controllers/AccountController.cs
+++ b/FactoryX.Web/Controllers/AccountController.cs
@@ -6,15 +6,16 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using FactoryX.Application.Services.Abstracts;
+using FactoryX.Application.DTOs.Requests.UserManagementRequests;
 
 namespace FactoryX.Web.Controllers;
 
 public class AccountController : Controller
 {
-    private readonly IUserService _userService;
-    public AccountController(IUserService userService)
+    private readonly IServiceManager _serviceManager;
+    public AccountController(IServiceManager serviceManager)
     {
-        _userService = userService;
+        _serviceManager = serviceManager;
     }
 
     [HttpGet]
@@ -29,7 +30,7 @@ public class AccountController : Controller
     {
         if (!ModelState.IsValid)
             return View(model);
-        var user = await _userService.AuthenticateAsync(new UserLoginDto { Username = model.Username, Password = model.Password });
+        var user = await _serviceManager.UserService.AuthenticateAsync(new UserLoginDto { Username = model.Username, Password = model.Password });
         if (user == null)
         {
             ModelState.AddModelError(string.Empty, "Invalid username or password.");
@@ -65,7 +66,7 @@ public class AccountController : Controller
             return View(model);
         try
         {
-            var user = await _userService.RegisterAsync(new UserRegisterDto { Username = model.Username, Password = model.Password, Role = model.Role });
+            var user = await _serviceManager.UserService.RegisterAsync(new UserRegisterDto { Username = model.Username, Password = model.Password, Role = model.Role });
             return RedirectToAction("Login");
         }
         catch (Exception ex)
@@ -87,7 +88,7 @@ public class AccountController : Controller
     public async Task<IActionResult> Profile()
     {
         var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
-        var profile = await _userService.GetProfileAsync(userId);
+        var profile = await _serviceManager.UserService.GetProfileAsync(userId);
         return View(profile);
     }
 
@@ -97,7 +98,7 @@ public class AccountController : Controller
     public async Task<IActionResult> Profile(UserProfileDto dto)
     {
         if (!ModelState.IsValid) return View(dto);
-        await _userService.UpdateProfileAsync(dto);
+        await _serviceManager.UserService.UpdateProfileAsync(dto);
         TempData["Success"] = "Profil başarıyla güncellendi.";
         return RedirectToAction("Profile");
     }
@@ -112,21 +113,26 @@ public class AccountController : Controller
     [Authorize]
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> ChangePassword(ChangePasswordDto dto)
+    public async Task<IActionResult> ChangePassword(ChangePasswordRequest request)
     {
-        dto.UserId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
-        if (!ModelState.IsValid) return View(dto);
-        var result = await _userService.ChangePasswordAsync(dto);
+        string? userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if(string.IsNullOrEmpty(userIdString) || !int.TryParse(userIdString, out var userId)) {
+            return Unauthorized();
+        }
+        if (!ModelState.IsValid) return View(request);
+
+        var result = await _serviceManager.UserService.ChangePasswordAsync(userId: userId, request);
         if (!result)
         {
             ModelState.AddModelError(string.Empty, "Mevcut şifre yanlış veya işlem başarısız.");
-            return View(dto);
+            return View(request);
         }
+
         TempData["Success"] = "Şifre başarıyla değiştirildi.";
         return RedirectToAction("Profile");
     }
 
-    private IActionResult RedirectToLocal(string? returnUrl)
+	private IActionResult RedirectToLocal(string? returnUrl)
     {
         if (!string.IsNullOrEmpty(returnUrl) && Url.IsLocalUrl(returnUrl))
             return Redirect(returnUrl);

--- a/FactoryX.Web/Controllers/HomeController.cs
+++ b/FactoryX.Web/Controllers/HomeController.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using FactoryX.Web.Models;
 using Microsoft.AspNetCore.Authorization;
-using FactoryX.Application.Services;
+using FactoryX.Application.Services.Abstracts;
 
 namespace FactoryX.Web.Controllers;
 

--- a/FactoryX.Web/Controllers/MachinesController.cs
+++ b/FactoryX.Web/Controllers/MachinesController.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using FactoryX.Application.Services;
 using FactoryX.Application.DTOs;
+using FactoryX.Application.Services.Abstracts;
 
 namespace FactoryX.Web.Controllers;
 

--- a/FactoryX.Web/Controllers/OperatorController.cs
+++ b/FactoryX.Web/Controllers/OperatorController.cs
@@ -1,5 +1,5 @@
 using FactoryX.Application.DTOs;
-using FactoryX.Application.Services;
+using FactoryX.Application.Services.Abstracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/FactoryX.Web/Controllers/ProductionRecordController.cs
+++ b/FactoryX.Web/Controllers/ProductionRecordController.cs
@@ -1,5 +1,5 @@
 using FactoryX.Application.DTOs;
-using FactoryX.Application.Services;
+using FactoryX.Application.Services.Abstracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;

--- a/FactoryX.Web/Controllers/ProductsController.cs
+++ b/FactoryX.Web/Controllers/ProductsController.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using FactoryX.Application.Services;
 using FactoryX.Application.DTOs;
+using FactoryX.Application.Services.Abstracts;
 
 namespace FactoryX.Web.Controllers;
 

--- a/FactoryX.Web/Controllers/ShiftController.cs
+++ b/FactoryX.Web/Controllers/ShiftController.cs
@@ -1,5 +1,5 @@
 using FactoryX.Application.DTOs;
-using FactoryX.Application.Services;
+using FactoryX.Application.Services.Abstracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/FactoryX.Web/Controllers/WorkOrderController.cs
+++ b/FactoryX.Web/Controllers/WorkOrderController.cs
@@ -1,5 +1,5 @@
 using FactoryX.Application.DTOs;
-using FactoryX.Application.Services;
+using FactoryX.Application.Services.Abstracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;

--- a/FactoryX.Web/Program.cs
+++ b/FactoryX.Web/Program.cs
@@ -1,9 +1,10 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
 using FactoryX.Infrastructure;
-using FactoryX.Application.Services;
 using FactoryX.Web.Services.Concretes;
 using FactoryX.Web.Services.Abstracts;
 using FactoryX.Web.Middlewares;
+using FactoryX.Application.Services.Concretes;
+using FactoryX.Application.Services.Abstracts;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -22,6 +23,7 @@ builder.Services.AddScoped<IWorkOrderService, WorkOrderService>();
 builder.Services.AddScoped<IOperatorService, OperatorService>();
 builder.Services.AddScoped<IProductionRecordService, ProductionRecordService>();
 builder.Services.AddScoped<IShiftService, ShiftService>();
+builder.Services.AddScoped<IServiceManager, ServiceManager>();
 
 // Web Services
 builder.Services.AddScoped<IFirstVisitService, FirstVisitService>();

--- a/FactoryX.Web/Views/Account/ChangePassword.cshtml
+++ b/FactoryX.Web/Views/Account/ChangePassword.cshtml
@@ -1,4 +1,4 @@
-@model FactoryX.Application.DTOs.ChangePasswordDto
+@model FactoryX.Application.DTOs.Requests.UserManagementRequests.ChangePasswordRequest
 @{
     ViewData["Title"] = "Şifre Değiştir";
 }

--- a/FactoryX.Web/Views/Account/ChangePassword.cshtml
+++ b/FactoryX.Web/Views/Account/ChangePassword.cshtml
@@ -5,6 +5,7 @@
 <partial name="_Alert" />
 <h2 class="fw-bold mb-4">Şifre Değiştir</h2>
 <form asp-action="ChangePassword" method="post" class="glass-card p-4 shadow-sm" autocomplete="off">
+    @Html.AntiForgeryToken()
     <div class="mb-3">
         <label asp-for="CurrentPassword" class="form-label">Mevcut Şifre</label>
         <input asp-for="CurrentPassword" class="form-control" type="password" />


### PR DESCRIPTION
Restructure namespaces for service interfaces and implementations, moving them to `FactoryX.Application.Services.Abstracts` and `FactoryX.Application.Services.Concretes`. Introduce `IServiceManager` to aggregate service interfaces for easier access. Update `BaseRepository` to use a generic type parameter `TEntity` for better type safety. Revise entity configurations to ensure proper EF Core setup. Register `IServiceManager` in `Program.cs` for dependency injection. Update controllers to reflect new service namespaces, enhancing code maintainability and clarity.