### PR TITLE
Refactor authentication responses and service methods

### DIFF
--- a/FactoryX.Application/DTOs/Responses/AuthenticationResponses/LoginResponse.cs
+++ b/FactoryX.Application/DTOs/Responses/AuthenticationResponses/LoginResponse.cs
@@ -1,6 +1,7 @@
 ﻿namespace FactoryX.Application.DTOs.Responses.AuthenticationResponses;
 
-public sealed record LoginResponse
-{
-
-}
+public sealed record LoginResponse(
+	int Id,
+	string Username,
+	string Role
+);

--- a/FactoryX.Application/DTOs/Responses/AuthenticationResponses/RegisterResponse.cs
+++ b/FactoryX.Application/DTOs/Responses/AuthenticationResponses/RegisterResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace FactoryX.Application.DTOs.Responses.AuthenticationResponses;
 
-public sealed record RegisterResponse
-{
-
-}
+public sealed record RegisterResponse(
+	int Id, 
+	string Username, 
+	string Role);

--- a/FactoryX.Application/Services/Abstracts/IUserService.cs
+++ b/FactoryX.Application/Services/Abstracts/IUserService.cs
@@ -1,12 +1,14 @@
 using FactoryX.Application.DTOs;
+using FactoryX.Application.DTOs.Requests.AuthenticationRequests;
 using FactoryX.Application.DTOs.Requests.UserManagementRequests;
+using FactoryX.Application.DTOs.Responses.AuthenticationResponses;
 
 namespace FactoryX.Application.Services.Abstracts;
 
 public interface IUserService
 {
-    Task<UserDto?> AuthenticateAsync(UserLoginDto loginDto);
-    Task<UserDto> RegisterAsync(UserRegisterDto registerDto);
+    Task<LoginResponse?> AuthenticateAsync(LoginRequest request);
+    Task<RegisterResponse> RegisterAsync(RegisterRequest request);
     Task<UserDto?> GetByIdAsync(int id);
     Task<UserDto?> GetByUsernameAsync(string username);
     Task<UserProfileDto?> GetProfileAsync(int userId);


### PR DESCRIPTION
Updated `LoginResponse` and `RegisterResponse` records to include `Id`, `Username`, and `Role`. Modified `IUserService` to change method signatures for `AuthenticateAsync` and `RegisterAsync` to use `LoginRequest` and `RegisterRequest`, returning the new response types. Adjusted `UserService` implementation to align with these changes, including password verification and user creation logic. Added necessary using directives for the new response types.