### PR TITLE
Refactor WorkOrder and Shift services with AutoMapper

### DIFF
--- a/FactoryX.Application/DTOs/Requests/WorkOrderRequests/UpdateWorkOrderRequest.cs
+++ b/FactoryX.Application/DTOs/Requests/WorkOrderRequests/UpdateWorkOrderRequest.cs
@@ -1,6 +1,7 @@
 ﻿namespace FactoryX.Application.DTOs.Requests.WorkOrderRequests;
 
 public sealed record UpdateWorkOrderRequest(
+	int Id,
 	int ProductId,
 	int MachineId,
 	int Quantity,

--- a/FactoryX.Application/Mappings/MappingProfile.cs
+++ b/FactoryX.Application/Mappings/MappingProfile.cs
@@ -1,5 +1,20 @@
 using AutoMapper;
 using FactoryX.Application.DTOs;
+using FactoryX.Application.DTOs.Requests.MachineRequests;
+using FactoryX.Application.DTOs.Requests.OperatorRequests;
+using FactoryX.Application.DTOs.Requests.ProductionRecordRequests;
+using FactoryX.Application.DTOs.Requests.ProductRequests;
+using FactoryX.Application.DTOs.Requests.ShiftRequests;
+using FactoryX.Application.DTOs.Requests.WorkOrderRequests;
+using FactoryX.Application.DTOs.Responses.MachineResponses;
+using FactoryX.Application.DTOs.Responses.Operator;
+using FactoryX.Application.DTOs.Responses.OperatorResponses;
+using FactoryX.Application.DTOs.Responses.Product;
+using FactoryX.Application.DTOs.Responses.ProductionRecord;
+using FactoryX.Application.DTOs.Responses.ProductResponses;
+using FactoryX.Application.DTOs.Responses.Shift;
+using FactoryX.Application.DTOs.Responses.ShiftResponses;
+using FactoryX.Application.DTOs.Responses.WorkOrder;
 using FactoryX.Domain.Entities;
 
 namespace FactoryX.Application.Mappings;
@@ -18,5 +33,53 @@ public class MappingProfile : Profile
         CreateMap<Product, ProductDto>().ReverseMap();
         CreateMap<MaterialUsage, MaterialUsageDto>().ReverseMap();
         CreateMap<ProductionRecord, ProductionRecordDto>().ReverseMap();
-    }
+
+		#region Machine Mapping
+		CreateMap<Machine, GetAllMachinesResponse>().ReverseMap();
+		CreateMap<Machine, GetMachineResponse?>().ReverseMap();
+        CreateMap<Machine, InsertMachineResponse>().ReverseMap();
+        CreateMap<Machine, InsertMachineRequest>().ReverseMap();
+        CreateMap<Machine, UpdateMachineRequest>().ReverseMap();
+        #endregion
+
+        #region Operator Mapping
+        CreateMap<Operator, GetAllOperatorResponse>().ReverseMap();
+        CreateMap<Operator, GetOperatorResponse?>().ReverseMap();
+        CreateMap<Operator, InsertOperatorRequest>().ReverseMap();
+        CreateMap<Operator, InsertOperatorResponse>().ReverseMap();
+        CreateMap<Operator, UpdateOperatorRequest>().ReverseMap();
+        #endregion
+
+        #region ProductionRecord Mapping
+        CreateMap<ProductionRecord, InsertProductionRecordRequest>().ReverseMap();
+        CreateMap<ProductionRecord, InsertProductionRecordResponse>().ReverseMap();
+        CreateMap<ProductionRecord, UpdateProductionRecordRequest>().ReverseMap();
+        #endregion
+
+        #region Product Mapping
+        CreateMap<Product, GetAllProductResponse>().ReverseMap();
+        CreateMap<Product, GetProductResponse>().ReverseMap();
+        CreateMap<Product, InsertProductRequest>().ReverseMap();
+        CreateMap<Product, InsertProductResponse>().ReverseMap();
+        CreateMap<Product, UpdateProductRequest>().ReverseMap();
+		#endregion
+
+		#region Shift Mapping
+        CreateMap<Shift, GetAllShiftResponse>().ReverseMap();
+        CreateMap<Shift, GetShiftResponse>().ReverseMap();
+        CreateMap<Shift, InsertShiftRequest>().ReverseMap();
+		CreateMap<Shift, InsertShiftResponse>().ReverseMap();
+		CreateMap<Shift, UpdateShiftRequest>().ReverseMap();
+		#endregion
+
+		#region User Mapping
+
+		#endregion
+
+		#region WorkOrder Mapping
+		CreateMap<WorkOrder, InsertWorkOrderRequest>().ReverseMap();
+		CreateMap<WorkOrder, InsertWorkOrderResponse>().ReverseMap();
+        CreateMap<WorkOrder, UpdateWorkOrderRequest>().ReverseMap();
+		#endregion
+	}
 }

--- a/FactoryX.Application/Services/Concretes/ProductionRecordService.cs
+++ b/FactoryX.Application/Services/Concretes/ProductionRecordService.cs
@@ -40,11 +40,11 @@ public class ProductionRecordService : IProductionRecordService
 
 	public async Task<InsertProductionRecordResponse> CreateAsync(InsertProductionRecordRequest request)
 	{
-		var workOrder = _mapper.Map<ProductionRecord>(request);
-		_repositoryManager.ProductionRecordRepository.Create(workOrder);
+		var productionRecord = _mapper.Map<ProductionRecord>(request);
+		_repositoryManager.ProductionRecordRepository.Create(productionRecord);
 		await _repositoryManager.SaveAsync();
 
-		return _mapper.Map<InsertProductionRecordResponse>(workOrder);
+		return _mapper.Map<InsertProductionRecordResponse>(productionRecord);
 	}
 
 	public async Task UpdateAsync(UpdateProductionRecordRequest request)


### PR DESCRIPTION
- Introduced `UpdateWorkOrderRequest` record with relevant properties.
- Refactored `ShiftService` to use `IRepositoryManager` and `IMapper`, simplifying CRUD operations.
- Updated `WorkOrderService` to utilize `IRepositoryManager` and `IMapper`, enhancing design and reducing complexity.
- Changed service methods to use new response DTOs for better data representation.
- Removed manual DTO conversion methods; now handled by AutoMapper for cleaner code.